### PR TITLE
Unstaged worktree scan - Potential fix

### DIFF
--- a/scan/unstaged.go
+++ b/scan/unstaged.go
@@ -273,7 +273,7 @@ func gitStatus(wt *git.Worktree, staggedOnly bool) (git.Status, error) {
 	c.Dir = wt.Filesystem.Root()
 	output, err := c.Output()
 	if err != nil {
-		stat, _ := wt.Status()
+		stat, err := wt.Status()
 		return stat, err
 	}
 
@@ -287,8 +287,7 @@ func gitStatus(wt *git.Worktree, staggedOnly bool) (git.Status, error) {
 		// For copy/rename the output looks like
 		//   R  destination\000source
 		// Which means we can split on space and ignore anything with only one result
-		x := line[0] // Merge (added to the change)
-		//y := line[1] // Workingtree (modified by not added to change)
+		x := line[0] // Status code of index (what has changed)
 		parts := strings.SplitN(strings.TrimLeft(line, " "), " ", 2)
 		if len(parts) == 2 {
 			if staggedOnly && !strings.ContainsAny(string(x), "MADRCU") {

--- a/scan/unstaged.go
+++ b/scan/unstaged.go
@@ -48,8 +48,12 @@ func GitStatus(path string) ([]string, error) {
 	var files []string
 	for _, line := range lines {
 		if len(line) > 0 && !strings.HasPrefix(line, "??") && !strings.HasPrefix(line, "??") {
-			r := []rune(line)
-			files = append(files, string(r[3:]))
+			r := string([]rune(line)[3:])
+			if strings.Contains(r, "->") {
+				split := strings.Split(r, "->")
+				r = strings.TrimSpace(split[1])
+			}
+			files = append(files, r)
 		}
 	}
 	return files, nil

--- a/scan/unstaged.go
+++ b/scan/unstaged.go
@@ -37,27 +37,6 @@ func NewUnstagedScanner(opts options.Options, cfg config.Config, repo *git.Repos
 	}
 	return us
 }
-func GitStatus(path string) ([]string, error) {
-	cmd := exec.Command("git", "status", "--porcelain")
-	cmd.Dir = path
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-	lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
-	var files []string
-	for _, line := range lines {
-		if len(line) > 0 && !strings.HasPrefix(line, "??") && !strings.HasPrefix(line, "??") {
-			r := string([]rune(line)[3:])
-			if strings.Contains(r, "->") {
-				split := strings.Split(r, "->")
-				r = strings.TrimSpace(split[1])
-			}
-			files = append(files, r)
-		}
-	}
-	return files, nil
-}
 
 // Scan kicks off an unstaged scan. This will attempt to determine unstaged changes which are then scanned.
 func (us *UnstagedScanner) Scan() (Report, error) {
@@ -68,11 +47,11 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 		if err != nil {
 			return scannerReport, err
 		}
-		status, err := GitStatus(wt.Filesystem.Root())
+		status, err := gitStatus(wt, true)
 		if err != nil {
 			return scannerReport, err
 		}
-		for _, fn := range status {
+		for fn := range status {
 			workTreeBuf := bytes.NewBuffer(nil)
 			workTreeFile, err := wt.Filesystem.Open(fn)
 			if err != nil {
@@ -164,7 +143,7 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 		return scannerReport, err
 	}
 
-	status, err := gitStatus(wt)
+	status, err := gitStatus(wt, false)
 	if err != nil {
 		return scannerReport, err
 	}
@@ -289,12 +268,12 @@ func diffPrettyText(diffs []diffmatchpatch.Diff) string {
 
 // gitStatus returns the status of modified files in the worktree. It will attempt to execute 'git status'
 // and will fall back to git.Worktree.Status() if that fails.
-func gitStatus(wt *git.Worktree) (git.Status, error) {
+func gitStatus(wt *git.Worktree, staggedOnly bool) (git.Status, error) {
 	c := exec.Command("git", "status", "--porcelain", "-z")
 	c.Dir = wt.Filesystem.Root()
 	output, err := c.Output()
 	if err != nil {
-		stat, err := wt.Status()
+		stat, _ := wt.Status()
 		return stat, err
 	}
 
@@ -308,11 +287,17 @@ func gitStatus(wt *git.Worktree) (git.Status, error) {
 		// For copy/rename the output looks like
 		//   R  destination\000source
 		// Which means we can split on space and ignore anything with only one result
+		x := line[0] // Merge (added to the change)
+		//y := line[1] // Workingtree (modified by not added to change)
 		parts := strings.SplitN(strings.TrimLeft(line, " "), " ", 2)
 		if len(parts) == 2 {
+			if staggedOnly && !strings.ContainsAny(string(x), "MADRCU") {
+				continue
+			}
 			stat[strings.Trim(parts[1], " ")] = &git.FileStatus{
 				Staging: git.StatusCode([]byte(parts[0])[0]),
 			}
+
 		}
 	}
 	return stat, err


### PR DESCRIPTION
Modified the gitStatus function there to provide the proper status of the git repo when working with worktrees. A bug in go-git  means basically all the files in the repo are considered modified. 
The function, when provided with `staggedOnly` will get a list of all files that have been added ready to commit. (Ignoring untracked, unmodified and ignored files).